### PR TITLE
Fix for completer plugin crash.

### DIFF
--- a/lib/plugins/completer.coffee
+++ b/lib/plugins/completer.coffee
@@ -15,12 +15,12 @@ module.exports = (settings) ->
     shell = settings.shell
     # Plug completer to interface
     return unless shell.isShell
-    shell.interface().completer = (text) ->
+    shell.interface().completer = (text, cb) ->
         suggestions = []
         routes = shell.routes
         for route in routes
             command = route.command
             if command.substr(0, text.length) is text
                 suggestions.push command
-        [suggestions, text]
+        cb(false, [suggestions, text])
     null


### PR DESCRIPTION
The completer plugin was causing node-shell to crash because a Node readline.js callback was being ignored. The diff didn't get submitted properly, lines changed are lib/plugins/completer.coffee:18 and lib/plugins/completer.coffee:25.
