### PR TITLE
stringify and compile methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Backward incompatibilities
 * parse: dont accept string command, only [string] and process
 * commands: only accept objects, no arrays
 * options: only accept objects, no arrays
+* compile: rename stringify method to compile
 
 New functionality
 * options: new disabled property

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Node.js Parameters is sugar for parsing typical unix command line options.
   * [Method `help`](https://github.com/adaltas/node-parameters/blob/master/doc/api/help.md)
   * [Method `helping`](https://github.com/adaltas/node-parameters/blob/master/doc/api/helping.md)
   * [Method `parse`](https://github.com/adaltas/node-parameters/blob/master/doc/api/parse.md)
-  * [Method `stringify`](https://github.com/adaltas/node-parameters/blob/master/doc/api/stringify.md)
+  * [Method `compile`](https://github.com/adaltas/node-parameters/blob/master/doc/api/compile.md)
   * [Method `route`](https://github.com/adaltas/node-parameters/blob/master/doc/api/route.md)
 * Usage and configuration
   * [Config](https://github.com/adaltas/node-parameters/blob/master/doc/config)

--- a/doc/api/compile.md
+++ b/doc/api/compile.md
@@ -1,25 +1,25 @@
 ---
-title: API method `stringify`
-description: How to use the `stringify` method to convert a parameters object to an arguments array.
-keywords: ["parameters", "node.js", "cli", "api", "stringify", "arguments", "argv", "array"]
+title: API method `compile`
+description: How to use the `compile` method to convert a parameters object to an arguments array.
+keywords: ["parameters", "node.js", "cli", "api", "compile", "arguments", "argv", "array"]
 maturity: review
 ---
 
-# Method `stringify(command, [options])`
+# Method `compile(command, [options])`
 
 Convert a parameters object to an arguments array.
 
 * `params`: `object` The parameter object to be converted into an array of arguments, optional.
-* `options`: `object` Options used to alter the behavior of the `stringify` method.
+* `options`: `object` Options used to alter the behavior of the `compile` method.
   * `extended`: `boolean` The value `true` indicates that the parameters are provided in extended format, default to the configuration `extended` value which is `false` by default.
   * `script`: `string` The JavaScript file being executed by the engine, when present, the engine and the script names will prepend the returned arguments, optional, default is false.
 * Returns: `array` The command line arguments.
 
 ## Description
 
-To stringify parameters is the reverse process of processing an array of arguments. In that sense, this module is bi-directional, it can both convert arguments to objects and back from objects to arguments.
+To compile parameters is the reverse process of processing an array of arguments. In that sense, this module is bi-directional, it can both convert arguments to objects and back from objects to arguments.
 
-It supports both the default flatten mode and the extended mode. The `extended` property can be defined in the configuration or as an option of `stringify`. In flatten mode, the `command` argument is an object while in `extended` mode it is an array of object.
+It supports both the default flatten mode and the extended mode. The `extended` property can be defined in the configuration or as an option of `compile`. In flatten mode, the `command` argument is an object while in `extended` mode it is an array of object.
 
 ## Examples
 
@@ -46,10 +46,10 @@ const app = parameters(
           description: "Web server listen port" } } } } })
 ```
 
-Called with only the `config` option, the `stringify` method convert a literal object into a shell command:
+Called with only the `config` option, the `compile` method convert a literal object into a shell command:
 
 ```javascript
-app.stringify({
+app.compile({
   config: "app.yaml"
 })
 .should.eql( [ "--config", "app.yaml" ] )
@@ -58,7 +58,7 @@ app.stringify({
 In extended mode, the parameters input will be an array instead of an object:
 
 ```js
-app.stringify([{
+app.compile([{
   config: "app.yaml"
 }], {
   extended: true
@@ -69,7 +69,7 @@ app.stringify([{
 Working with commands is quite similar:
 
 ```js
-app.stringify({
+app.compile({
   config: "app.yml",
   command: ["start"],
   host: "127.0.0.1",
@@ -82,7 +82,7 @@ app.stringify({
 In extended mode, the parameters input will be an array with 2 elements instead of an object:
 
 ```js
-app.stringify([{
+app.compile([{
   config: "app.yml"
 },{
   command: "start",

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -1,7 +1,7 @@
 ---
 title: API
 description: API methods supported.
-keywords: ['parameters', 'node.js', 'cli', 'api', 'help', 'parse', 'load', 'route', 'stringify']
+keywords: ['parameters', 'node.js', 'cli', 'api', 'help', 'parse', 'load', 'route', 'compile']
 maturity: review
 ---
 
@@ -27,5 +27,5 @@ expecting a configuration object and returning the following functions:
   first argument. If the option "extended" is activated, it also receives the
   original arguments and configuration as second and third arguments. Any user
   provided arguments are transmitted as is as additional arguments.
-* [`stringify`](./stringify/) (command, [options])   
+* [`compile`](./compile/) (command, [options])   
   Convert a parameters object to an arguments array.

--- a/doc/api/parse.md
+++ b/doc/api/parse.md
@@ -10,7 +10,7 @@ maturity: review
 Convert an arguments list to a parameters object.
 
 * `arguments`: `[string] | process` The arguments to parse into parameters, accept the [Node.js process](https://nodejs.org/api/process.html) instance or an [argument list](https://nodejs.org/api/process.html#process_process_argv) provided as an array or a string, optional, default to `process`.
-* `options`: `object` Options used to alter the behavior of the `stringify` method.
+* `options`: `object` Options used to alter the behavior of the `compile` method.
   * `extended`: `boolean` The value `true` indicates that the parameters are returned in extended format, default to the configuration `extended` value which is `false` by default.
 * Returns: `object | [object]` The extracted parameters, a literal object in default flatten mode or an array in extended mode.
 

--- a/doc/config/options.md
+++ b/doc/config/options.md
@@ -15,7 +15,7 @@ Options define the arguments passed to a shell scripts when prefixed with `--` f
 
 * `default` (anything)   
   Default value if none is provided; always part of the object return by parse,
-  part of the arguments returned by [`stringify`](/api/stringify/) unless the "no_default" option is set.
+  part of the arguments returned by [`compile`](/api/compile/) unless the "no_default" option is set.
 * `disabled` (boolean, optional, false)   
   Disabled an option.
 * `name` (string)   

--- a/lib/Parameters.js
+++ b/lib/Parameters.js
@@ -59,11 +59,9 @@ Parameters.prototype.hook = function() {
       handler = hook[name].call(this, args, handler);
     }
   }
-  console.log('==', hooks);
   if (hooks) {
     for (l = 0, len2 = hooks.length; l < len2; l++) {
       hook = hooks[l];
-      console.log('=?', hook);
       handler = hook.call(this, args, handler);
     }
   }
@@ -75,7 +73,7 @@ Parameters.prototype.hook = function() {
 // Convert an arguments list to a parameters object.
 
 // * `arguments`: `[string] | process` The arguments to parse into parameters, accept the [Node.js process](https://nodejs.org/api/process.html) instance or an [argument list](https://nodejs.org/api/process.html#process_process_argv) provided as an array or a string, optional.
-// * `options`: `object` Options used to alter the behavior of the `stringify` method.
+// * `options`: `object` Options used to alter the behavior of the `compile` method.
 //   * `extended`: `boolean` The value `true` indicates that the parameters are returned in extended format, default to the configuration `extended` value which is `false` by default.
 // * Returns: `object | [object]` The extracted parameters, a literal object in default flatten mode or an array in extended mode.
 Parameters.prototype.parse = function(argv = process, options = {}) {
@@ -260,24 +258,24 @@ Parameters.prototype.parse = function(argv = process, options = {}) {
   return params;
 };
 
-// ## Method `stringify(command, [options])`
+// ## Method `compile(command, [options])`
 
 // Convert a parameters object to an arguments array.
 
 // * `params`: `object` The parameter object to be converted into an array of arguments, optional.
-// * `options`: `object` Options used to alter the behavior of the `stringify` method.
+// * `options`: `object` Options used to alter the behavior of the `compile` method.
 //   * `extended`: `boolean` The value `true` indicates that the parameters are provided in extended format, default to the configuration `extended` value which is `false` by default.
 //   * `script`: `string` The JavaScript file being executed by the engine, when present, the engine and the script names will prepend the returned arguments, optional, default is false.
 // * Returns: `array` The command line arguments.
-Parameters.prototype.stringify = function(params, options = {}) {
-  var appconfig, argv, keys, stringify;
+Parameters.prototype.compile = function(params, options = {}) {
+  var appconfig, argv, compile, keys;
   argv = options.script ? [process.execPath, options.script] : [];
   appconfig = this.confx().get();
   if (options.extended == null) {
     options.extended = appconfig.extended;
   }
   if (!is_object_literal(options)) {
-    throw error(['Invalid Stringify Arguments:', '2nd argument option must be an object,', `got ${JSON.stringify(options)}`]);
+    throw error(['Invalid Compile Arguments:', '2nd argument option must be an object,', `got ${JSON.stringify(options)}`]);
   }
   keys = {};
   // In extended mode, the params array will be truncated
@@ -287,8 +285,8 @@ Parameters.prototype.stringify = function(params, options = {}) {
     // Convert command parameter to a 1 element array if provided as a string
     params[appconfig.command] = [params[appconfig.command]];
   }
-  // Stringify
-  stringify = function(config, lparams) {
+  // Compile
+  compile = function(config, lparams) {
     var _, command, has_child_commands, i, key, len, option, ref, results, val, value;
     ref = config.options;
     for (_ in ref) {
@@ -351,8 +349,8 @@ Parameters.prototype.stringify = function(params, options = {}) {
       }
       argv.push(command);
       keys[appconfig.command] = command;
-      // Stringify child configuration
-      stringify(config.commands[command], options.extended ? params.shift() : lparams);
+      // Compile child configuration
+      compile(config.commands[command], options.extended ? params.shift() : lparams);
     }
     if (options.extended || !has_child_commands) {
 // Handle params not defined in the configuration
@@ -383,7 +381,7 @@ Parameters.prototype.stringify = function(params, options = {}) {
       return results;
     }
   };
-  stringify(appconfig, options.extended ? params.shift() : params);
+  compile(appconfig, options.extended ? params.shift() : params);
   return argv;
 };
 

--- a/samples/commands.js
+++ b/samples/commands.js
@@ -48,7 +48,7 @@ command.parse(
   port: 80
 });
 // Create a command
-command.stringify({
+command.compile({
   command: ['start'],
   host: '127.0.0.1',
   port: 80

--- a/samples/standard.js
+++ b/samples/standard.js
@@ -38,7 +38,7 @@ command.parse(
   port: 80
 });
 // Create a command
-command.stringify({
+command.compile({
   host: '127.0.0.1',
   port: 80
 }).should.eql(

--- a/src/Parameters.coffee.md
+++ b/src/Parameters.coffee.md
@@ -52,7 +52,7 @@
 Convert an arguments list to a parameters object.
 
 * `arguments`: `[string] | process` The arguments to parse into parameters, accept the [Node.js process](https://nodejs.org/api/process.html) instance or an [argument list](https://nodejs.org/api/process.html#process_process_argv) provided as an array or a string, optional.
-* `options`: `object` Options used to alter the behavior of the `stringify` method.
+* `options`: `object` Options used to alter the behavior of the `compile` method.
   * `extended`: `boolean` The value `true` indicates that the parameters are returned in extended format, default to the configuration `extended` value which is `false` by default.
 * Returns: `object | [object]` The extracted parameters, a literal object in default flatten mode or an array in extended mode.
 
@@ -200,22 +200,22 @@ Convert an arguments list to a parameters object.
       set_default appconfig, params
       params
 
-## Method `stringify(command, [options])`
+## Method `compile(command, [options])`
 
 Convert a parameters object to an arguments array.
 
 * `params`: `object` The parameter object to be converted into an array of arguments, optional.
-* `options`: `object` Options used to alter the behavior of the `stringify` method.
+* `options`: `object` Options used to alter the behavior of the `compile` method.
   * `extended`: `boolean` The value `true` indicates that the parameters are provided in extended format, default to the configuration `extended` value which is `false` by default.
   * `script`: `string` The JavaScript file being executed by the engine, when present, the engine and the script names will prepend the returned arguments, optional, default is false.
 * Returns: `array` The command line arguments.
 
-    Parameters::stringify = (params, options={}) ->
+    Parameters::compile = (params, options={}) ->
       argv = if options.script then [process.execPath, options.script] else []
       appconfig = @confx().get()
       options.extended ?= appconfig.extended
       throw error [
-        'Invalid Stringify Arguments:'
+        'Invalid Compile Arguments:'
         '2nd argument option must be an object,'
         "got #{JSON.stringify options}"
       ] unless is_object_literal options
@@ -225,8 +225,8 @@ Convert a parameters object to an arguments array.
       set_default appconfig, params
       # Convert command parameter to a 1 element array if provided as a string
       params[appconfig.command] = [params[appconfig.command]] if typeof params[appconfig.command] is 'string'
-      # Stringify
-      stringify = (config, lparams) ->
+      # Compile
+      compile = (config, lparams) ->
         for _, option of config.options
           key = option.name
           keys[key] = true
@@ -281,8 +281,8 @@ Convert a parameters object to an arguments array.
           ] unless config.commands[command]
           argv.push command
           keys[appconfig.command] = command
-          # Stringify child configuration
-          stringify config.commands[command], if options.extended then params.shift() else lparams
+          # Compile child configuration
+          compile config.commands[command], if options.extended then params.shift() else lparams
         if options.extended or not has_child_commands
           # Handle params not defined in the configuration
           # Note, they are always pushed to the end and associated with the deepest child
@@ -299,7 +299,7 @@ Convert a parameters object to an arguments array.
             else
               argv.push "--#{key}"
               argv.push "#{value}"
-      stringify appconfig, if options.extended then params.shift() else params
+      compile appconfig, if options.extended then params.shift() else params
       argv
 
 ## `load(module)`

--- a/test/api.compile.coffee
+++ b/test/api.compile.coffee
@@ -1,25 +1,25 @@
 
 parameters = require '../src'
 
-describe 'api.stringify', ->
+describe 'api.compile', ->
 
   it 'validate', ->
     (->
       parameters()
-      .stringify {}, 'invalid'
-    ).should.throw 'Invalid Stringify Arguments: 2nd argument option must be an object, got "invalid"'
+      .compile {}, 'invalid'
+    ).should.throw 'Invalid Compile Arguments: 2nd argument option must be an object, got "invalid"'
   
   it 'command string is converted to a 1 element array internally', ->
     parameters
       commands: 'start': {}
-    .stringify command: 'start'
+    .compile command: 'start'
     .should.eql ['start']
     
   it 'catch main argument with type of string', ->
     (->
       parameters
         main: 'leftover'
-      .stringify
+      .compile
         leftover: 'my value'
     ).should.throw 'Invalid Parameter Type: expect main to be an array, got "my value"'
   
@@ -29,7 +29,7 @@ describe 'api.stringify', ->
         commands:
           'start': {}
           'stop': {}
-      .stringify
+      .compile
         command: ['status']
     ).should.throw 'Invalid Command Parameter: command "status" is not registed, expect one of ["help","start","stop"]'
     (->
@@ -37,6 +37,6 @@ describe 'api.stringify', ->
         commands: 'server': commands:
           'start': {}
           'stop': {}
-      .stringify
+      .compile
         command: ['server', 'status']
     ).should.throw 'Invalid Command Parameter: command "status" is not registed, expect one of ["start","stop"] in command "server"'

--- a/test/api.compile.script.coffee
+++ b/test/api.compile.script.coffee
@@ -1,13 +1,13 @@
 
 parameters = require '../src'
 
-describe 'api.stringify.script', ->
+describe 'api.compile.script', ->
 
   it 'should prefix with node path and executed script', ->
     parameters
       commands: 'start':
         options: 'myparam': {}
-    .stringify
+    .compile
       command: 'start'
       myparam: 'my value'
     ,

--- a/test/api.hook.coffee
+++ b/test/api.hook.coffee
@@ -23,12 +23,11 @@ describe 'api.hook', ->
     , ({pass}) ->
       pass.should.eql 'sth'
         
-  it.only 'provide user register', ->
+  it 'provide user register', ->
     app = parameters()
     app.hook 'hook_sth',
       pass: 'sth'
     , (context, handler) ->
-      console.log 'ok'
       context.pass = 'sth else'
       handler
     , ({pass}) ->

--- a/test/commands.coffee
+++ b/test/commands.coffee
@@ -9,7 +9,7 @@ describe 'commands', ->
     app.parse ['start']
     .should.eql
       command: ['start']
-    app.stringify
+    app.compile
       command: ['start']
     .should.eql ['start']
 
@@ -25,7 +25,7 @@ describe 'commands', ->
     .should.eql
       command: ['start']
       myparam: 'my value'
-    app.stringify
+    app.compile
       command: ['start']
       myparam: 'my value'
     .should.eql ['start', '--myparam', 'my value']
@@ -37,7 +37,7 @@ describe 'commands', ->
     app.parse ['start']
     .should.eql
       mycommand: ['start']
-    app.stringify
+    app.compile
       mycommand: ['start']
     .should.eql ['start']
 
@@ -53,7 +53,7 @@ describe 'commands', ->
       gopt: 'toto'
       command: ['start']
       aopt: 'lulu'
-    app.stringify
+    app.compile
       gopt: 'toto'
       command: ['start']
       aopt: 'lulu'
@@ -76,7 +76,7 @@ describe 'commands', ->
         opt_root: 'val 0'
         opt_parent: 'val 1'
         opt_child: 'val 2'
-      app.stringify
+      app.compile
         command: ['parent', 'child']
         opt_root: 'val 0'
         opt_parent: 'val 1'

--- a/test/config/extended.coffee
+++ b/test/config/extended.coffee
@@ -34,11 +34,11 @@ describe 'config.extended', ->
         leftover: ['my value']
       ]
       app.parse([]).should.eql [{}]
-      app.stringify [
+      app.compile [
         leftover: ['my value']
       ]
       .should.eql ['my value']
-      app.stringify([{}]).should.eql []
+      app.compile([{}]).should.eql []
     
     it 'application with configured commands get leftover', ->
       app = parameters
@@ -50,7 +50,7 @@ describe 'config.extended', ->
       app.parse(['my --command']).should.eql [
         leftover: ['my --command']
       ]
-      app.stringify [
+      app.compile [
         leftover: ['my --command']
       ]
       .should.eql ['my --command']

--- a/test/help/help.parse.coffee
+++ b/test/help/help.parse.coffee
@@ -37,7 +37,7 @@ describe 'help/help.parse', ->
     app.parse ['help']
     .should.eql
       command: ['help']
-    app.stringify
+    app.compile
       command: ['help']
     .should.eql ['help']
 
@@ -48,7 +48,7 @@ describe 'help/help.parse', ->
     .should.eql
       command: ['help']
       name: ['start']
-    app.stringify
+    app.compile
       command: ['help']
       name: ['start']
     .should.eql ['help', 'start']

--- a/test/main.coffee
+++ b/test/main.coffee
@@ -28,7 +28,7 @@ describe 'main', ->
         main:
           name: 'leftover'
       app.parse([]).should.eql {}
-      app.stringify({}).should.eql []
+      app.compile({}).should.eql []
 
     it 'preserve space in main arguments', ->
       app = parameters
@@ -39,7 +39,7 @@ describe 'main', ->
       ]
       .should.eql
         leftover: ['my value']
-      app.stringify
+      app.compile
         leftover: ['my value']
       .should.eql ['my value']
 
@@ -52,7 +52,7 @@ describe 'main', ->
       ]
       .should.eql
         leftover: ['my', 'value']
-      app.stringify
+      app.compile
         leftover: ['my', 'value']
       .should.eql ['my', 'value']
   
@@ -69,7 +69,7 @@ describe 'main', ->
       .should.eql
         command: ['start']
         leftover: ['my', 'value true']
-      app.stringify
+      app.compile
         command: ['start']
         leftover: ['my', 'value true']
       .should.eql ['start', 'my', 'value true']
@@ -86,7 +86,7 @@ describe 'main', ->
       .should.eql
         command: ['mycommand']
         leftover: ['my value']
-      app.stringify
+      app.compile
         command: ['mycommand']
         leftover: ['my value']
       .should.eql ['mycommand', 'my value']

--- a/test/main.required.coffee
+++ b/test/main.required.coffee
@@ -13,7 +13,7 @@ describe 'main.required', ->
     ]
     .should.eql
       command: ['mycommand']
-    app.stringify
+    app.compile
       command: ['mycommand']
     .should.eql ['mycommand']
 
@@ -29,7 +29,7 @@ describe 'main.required', ->
     .should.eql
       command: ['mycommand']
       my_argument: ['my --value']
-    app.stringify
+    app.compile
       command: ['mycommand']
       my_argument: ['my --value']
     .should.eql ['mycommand', 'my --value']
@@ -44,6 +44,6 @@ describe 'main.required', ->
       app.parse ['mycommand']
     ).should.throw 'Required Main Argument: no suitable arguments for "my_argument"'
     (->
-      app.stringify
+      app.compile
         command: ['mycommand']
     ).should.throw 'Required Main Parameter: no suitable arguments for "my_argument"'

--- a/test/options.coffee
+++ b/test/options.coffee
@@ -31,7 +31,7 @@ describe 'options', ->
       ]
       .should.eql
         myparam: 'my value'
-      app.stringify
+      app.compile
         myparam: 'my value'
       .should.eql ['--myparam', 'my value']
 
@@ -55,7 +55,7 @@ describe 'options', ->
         watch: __dirname
         strict: true
         my_argument: ['my', '--value']
-      app.stringify
+      app.compile
         command: ['start']
         watch: __dirname
         strict: true

--- a/test/options.default.coffee
+++ b/test/options.default.coffee
@@ -12,7 +12,7 @@ describe 'options.default', ->
       app.parse []
       .should.eql
         my_argument: 'default value'
-      app.stringify {}
+      app.compile {}
       .should.eql ['--my_argument', 'default value']
 
   describe 'with commands', ->
@@ -28,7 +28,7 @@ describe 'options.default', ->
       .should.eql
         command: ['my_command']
         my_argument: 'default value'
-      app.stringify command: ['my_command']
+      app.compile command: ['my_command']
       .should.eql ['my_command', '--my_argument', 'default value']
           
     it 'preserve global option', ->
@@ -42,5 +42,5 @@ describe 'options.default', ->
         command: ['my_command']
         global_argument: 'global value'
         command_argument: 'command value'
-      app.stringify command: ['my_command']
+      app.compile command: ['my_command']
       .should.eql ['--global_argument', 'global value', 'my_command', '--command_argument', 'command value']

--- a/test/options.discovery.coffee
+++ b/test/options.discovery.coffee
@@ -10,7 +10,7 @@ describe 'options.discovery', ->
     ]
     .should.eql
       myoption: 'my value'
-    app.stringify
+    app.compile
       myoption: 'my value'
     .should.eql ['--myoption', 'my value']
 
@@ -19,7 +19,7 @@ describe 'options.discovery', ->
     app.parse(['mycommand', '--myoption', 'my value']).should.eql
       command: ['mycommand']
       myoption: 'my value'
-    app.stringify
+    app.compile
       command: ['mycommand']
       myoption: 'my value'
     .should.eql ['mycommand', '--myoption', 'my value']
@@ -28,6 +28,6 @@ describe 'options.discovery', ->
     app = parameters()
     app.parse(['--myoption']).should.eql
       myoption: true
-    app.stringify
+    app.compile
       myoption: true
     .should.eql ['--myoption']

--- a/test/options.one_of.coffee
+++ b/test/options.one_of.coffee
@@ -14,7 +14,7 @@ describe 'options.one_of', ->
     .should.eql
       command: ['start']
       array: ['1','2']
-    app.stringify
+    app.compile
       command: ['start']
       array: ['1','2']
     .should.eql ['start', '--array', '1,2']
@@ -29,7 +29,7 @@ describe 'options.one_of', ->
       app.parse(['start', '-a', '1', '-a', '2'])
     ).should.throw 'Invalid Argument Value: the value of option "array" must be one of ["1","3"], got "2"'
     (->
-      app.stringify command: ['start'], array: ['1','2']
+      app.compile command: ['start'], array: ['1','2']
     ).should.throw 'Invalid Parameter Value: the value of option "array" must be one of ["1","3"], got "2"'
   
   it 'ensure optional argument are optional', ->

--- a/test/options.required.coffee
+++ b/test/options.required.coffee
@@ -12,7 +12,7 @@ describe 'options.required', ->
       app.parse ['mycommand']
       .should.eql
         command: ['mycommand']
-      app.stringify
+      app.compile
         command: ['mycommand']
       .should.eql ['mycommand']
 
@@ -24,7 +24,7 @@ describe 'options.required', ->
       app.parse ['mycommand']
       .should.eql
         command: ['mycommand']
-      app.stringify
+      app.compile
         command: ['mycommand']
       .should.eql ['mycommand']
 
@@ -39,7 +39,7 @@ describe 'options.required', ->
       .should.eql
         command: ['mycommand']
         my_argument: 'my --value'
-      app.stringify
+      app.compile
         command: ['mycommand']
         my_argument: 'my --value'
       .should.eql ['mycommand', '--my_argument', 'my --value']
@@ -53,7 +53,7 @@ describe 'options.required', ->
         app.parse ['mycommand']
       ).should.throw 'Required Option Argument: the "my_argument" option must be provided'
       (->
-        app.stringify
+        app.compile
           command: ['mycommand']
       ).should.throw 'Required Option Parameter: the "my_argument" option must be provided'
   

--- a/test/options.strict.coffee
+++ b/test/options.strict.coffee
@@ -9,7 +9,7 @@ describe 'options.strict', ->
       app.parse ['--myoption', 'my', '--command']
     ).should.throw 'Invalid Argument: the argument --myoption is not a valid option'
     (->
-      app.stringify
+      app.compile
         myoption: true
     ).should.throw 'Invalid Parameter: the property --myoption is not a registered argument'
 
@@ -19,7 +19,7 @@ describe 'options.strict', ->
       app.parse ['mycommand', '--myoption', 'my', '--command']
     ).should.throw 'Invalid Argument: the argument --myoption is not a valid option'
     (->
-      app.stringify
+      app.compile
         command: 'mycommand'
         myoption: true
     ).should.throw 'Invalid Parameter: the property --myoption is not a registered argument'

--- a/test/options.types.coffee
+++ b/test/options.types.coffee
@@ -13,7 +13,7 @@ describe 'options.type', ->
       app.parse(['start', '--watch', __dirname]).should.eql
         command: ['start']
         watch: __dirname
-      app.stringify
+      app.compile
         command: ['start']
         watch: __dirname
       .should.eql ['start', '--watch', __dirname]
@@ -29,7 +29,7 @@ describe 'options.type', ->
       app.parse(['start', '-s']).should.eql
         command: ['start']
         strict: true
-      app.stringify
+      app.compile
         command: ['start']
         strict: true
       .should.eql ['start', '--strict']
@@ -39,7 +39,7 @@ describe 'options.type', ->
         options: 'detached':
           shortcut: 'd'
           type: 'boolean'
-      app.stringify
+      app.compile
         detached: null
       .should.eql []
 
@@ -54,7 +54,7 @@ describe 'options.type', ->
       app.parse(['start', '-i', '5']).should.eql
         command: ['start']
         integer: 5
-      app.stringify
+      app.compile
         command: ['start']
         integer: 5
       .should.eql ['start', '--integer', '5']
@@ -71,7 +71,7 @@ describe 'options.type', ->
       .should.eql
         command: ['start']
         array: ['3','2','1']
-      app.stringify
+      app.compile
         command: ['start']
         array: ['3','2','1']
       .should.eql ['start', '--array', '3,2,1']
@@ -85,7 +85,7 @@ describe 'options.type', ->
       app.parse(['start', '-a', '3', '-a', '2', '-a', '1']).should.eql
         command: ['start']
         array: ['3','2','1']
-      app.stringify
+      app.compile
         command: ['start']
         array: ['3','2','1']
       .should.eql ['start', '--array', '3,2,1']
@@ -98,7 +98,7 @@ describe 'options.type', ->
       app.parse(['start', '--my_array', '', '--my_array', '2', '--my_array', '']).should.eql
         command: ['start']
         my_array: ['','2','']
-      app.stringify
+      app.compile
         command: ['start']
         array: ['','2','']
       .should.eql ['start', '--array', ',2,']

--- a/test/router/handler.coffee
+++ b/test/router/handler.coffee
@@ -10,7 +10,7 @@ describe 'router.handler', ->
       route: ({params}) ->
         @should.have.property('help').which.is.a.Function()
         @should.have.property('parse').which.is.a.Function()
-        @should.have.property('stringify').which.is.a.Function()
+        @should.have.property('compile').which.is.a.Function()
     .route []
 
   it 'propagate error', ->


### PR DESCRIPTION
Rename `stringify` to `compile` everywhere. This closes #22 